### PR TITLE
Updated docker-proxy to work on newer centos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,16 @@ FROM hpess/chef:master
 COPY patch.txt /usr/local/src/patch.txt
 
 # Install pre-reqs
-RUN yum -y -q install perl-Crypt-OpenSSL-X509 openssl openssl-devel gcc gcc-c++ patch python dnsmasq net-tools telnet bind-utils && \
+RUN \
+    user=$(echo $http_proxy | sed "s#.*://\(.*\):.*@.*#\1#g") && \
+    password=$(echo $http_proxy | sed "s#.*://.*:\(.*\)@.*#\1#g") && \
+    server=$(echo $http_proxy | sed "s#.*://.*:.*@\(.*\)#\1#g") && \
+    [[ -n "$user" ]] && echo "proxy_username=$user" >> /etc/yum.conf && \
+    [[ -n "$password" ]] && echo "proxy_password=$password" >> /etc/yum.conf && \
+    [[ -n "$server" ]] && echo "proxy=http://$server" >> /etc/yum.conf && \
+    cat /etc/yum.conf && \
+    yum -y -q erase fakesystemd && \
+    yum -y -q install perl-Crypt-OpenSSL-X509 openssl openssl-devel gcc gcc-c++ patch python dnsmasq net-tools telnet bind-utils && \
     cd /usr/local/src && \
     wget -q http://www.squid-cache.org/Versions/v3/3.5/squid-3.5.0.4.tar.gz && \
     tar -xzf squid-3.5.0.4.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ sudo docker run -it -d --privileged --net=host -e="cache_peer=your.upstream.prox
 ```
 If you are building the docker container behind a proxy you can use docker as this:
 ```
-docker build --privileged --build-arg http_proxy=your.upstream.proxy -t hpess/dockerproxy .
-docker run --name dockerproxy -it --privileged --net=host -e="cache_peer=your.upstream.proxy" hpess/dockerproxy
+docker build --privileged --build-arg http_proxy=your.upstream.proxy -t dockerproxy .
+docker run --name dockerproxy -it --privileged --net=host -e="cache_peer=your.upstream.proxy" dockerproxy
 ```
 The available environment variables are:
   - cache_peer: This is your corporate/second proxy that squid should backend on to, if you don't specify an upstream proxy - all requests will be sent direct (always_direct)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ Or you can just use docker
 ```
 sudo docker run -it -d --privileged --net=host -e="cache_peer=your.upstream.proxy" hpess/dockerproxy
 ```
+If you are building the docker container behind a proxy you can use docker as this:
+```
+docker build --privileged --build-arg http_proxy=your.upstream.proxy -t dockerproxy .
+docker run --name dockerproxy -it --privileged --net=host -e="cache_peer=your.upstream.proxy" dockerproxy
+```
 The available environment variables are:
   - cache_peer: This is your corporate/second proxy that squid should backend on to, if you don't specify an upstream proxy - all requests will be sent direct (always_direct)
   - cache_peer_port: The port of your second proxy, defaults to 8080

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ sudo docker run -it -d --privileged --net=host -e="cache_peer=your.upstream.prox
 ```
 If you are building the docker container behind a proxy you can use docker as this:
 ```
-docker build --privileged --build-arg http_proxy=your.upstream.proxy -t dockerproxy .
-docker run --name dockerproxy -it --privileged --net=host -e="cache_peer=your.upstream.proxy" dockerproxy
+docker build --privileged --build-arg http_proxy=your.upstream.proxy -t hpess/dockerproxy .
+docker run --name dockerproxy -it --privileged --net=host -e="cache_peer=your.upstream.proxy" hpess/dockerproxy
 ```
 The available environment variables are:
   - cache_peer: This is your corporate/second proxy that squid should backend on to, if you don't specify an upstream proxy - all requests will be sent direct (always_direct)


### PR DESCRIPTION
Corrected some some bugs due to fakesystemd with recent centos release.

Added ability to build the docker through a proxy

Tested, there is some warnings with chef but it's working